### PR TITLE
Refactor check protocol rename all args to args

### DIFF
--- a/src/pandas_contract/_decorator_v2.py
+++ b/src/pandas_contract/_decorator_v2.py
@@ -344,5 +344,4 @@ def _check_fn_args(prefix: str, fn: MyFunctionType, args: Iterable[str]) -> None
 def _collect_args(args: Iterable[str], checks: Iterable[Any]) -> Iterable[str]:
     yield from args
     for check in checks:
-        if hasattr(check, "all_args"):
-            yield from check.all_args
+        yield from getattr(check, "args", ())

--- a/src/pandas_contract/_private_checks.py
+++ b/src/pandas_contract/_private_checks.py
@@ -22,7 +22,7 @@ class Check(Protocol):  # pragma: no cover
     """Protocol for a DataFrame or Series check class."""
 
     @property
-    def all_args(self) -> Sequence[str]:
+    def args(self) -> Sequence[str]:
         """Get a list of all arguments."""
         ...
 
@@ -66,7 +66,7 @@ class CheckSchema:
         return self.schema is not None
 
     @property
-    def all_args(self) -> list[str]:
+    def args(self) -> list[str]:
         return []
 
     def mk_check(

--- a/src/tests/unit_tests/test_checks.py
+++ b/src/tests/unit_tests/test_checks.py
@@ -26,7 +26,7 @@ class TestCheckExtends:
         """Test initialization of CheckExtends."""
         modified = DataFrameSchema()
         check = extends("df", modified=modified)
-        assert check.arg == "df"
+        assert check.args == ("df",)
         assert check.modified.schema is modified
 
     @pytest.mark.parametrize(

--- a/src/tests/unit_tests/test_checks.py
+++ b/src/tests/unit_tests/test_checks.py
@@ -114,16 +114,16 @@ class TestIs:
         res = is_("df")
         df = pd.DataFrame(index=[])
         fn = res.mk_check(lambda df: df, (df,), {})
-        assert fn(df) == []
-        assert fn(df.copy()) == ["is not df"]
+        assert list(fn(df)) == []
+        assert list(fn(df.copy())) == ["is not df"]
 
     def test_check_none(self) -> None:
         """Test for inplace argument."""
         res = is_(None)
         df = pd.DataFrame(index=[])
         fn = res.mk_check(lambda df: df, (df,), {})
-        assert fn(df) == []
-        assert fn(df.copy()) == []
+        assert list(fn(df)) == []
+        assert list(fn(df.copy())) == []
 
 
 class TestCheckIsNot:
@@ -136,3 +136,10 @@ class TestCheckIsNot:
     def test_is_active(self, others: Sequence[str], is_active: bool) -> None:
         """Test is_active property of CheckIsNot."""
         assert is_not(others).is_active == is_active
+
+    def test_check(self) -> None:
+        """Test is_not.mk_check."""
+        df = pd.DataFrame()
+        check_fn = is_not("df").mk_check(lambda df: None, (df,), {})
+        assert list(check_fn(df.copy())) == []
+        assert list(check_fn(df)) == ["is df"]


### PR DESCRIPTION
Rename Checks protocol argument all_args to args, rewrite checks such that they all use args directly.
## BREAKING
is_not is not a dataclass anymore.